### PR TITLE
Add includes for standard library objects

### DIFF
--- a/source/ham/jamulfont.cpp
+++ b/source/ham/jamulfont.cpp
@@ -1,6 +1,9 @@
 #include "jamulfont.h"
 #include "mgldraw.h"
 
+// Standard header includes
+#include <stdio.h>
+
 MGLDraw *fontmgl;
 // this is a sort of palette translation table for the font
 byte fontPal[256];

--- a/source/supreme/levelscan.cpp
+++ b/source/supreme/levelscan.cpp
@@ -6,6 +6,9 @@
 #include "shop.h"
 #include "control.h"
 
+// Standard header includes
+#include<algorithm>
+
 static FILE *scanF;
 
 static char lvlFlagName[][16]={


### PR DESCRIPTION
Two files use standard library content without include the appropriate headers. This prevents compilation if you're using Visual Studio.