### PR TITLE
Include stddef.h in lzma_helpers.h

### DIFF
--- a/source/vanilla_extract/lzma_helpers.h
+++ b/source/vanilla_extract/lzma_helpers.h
@@ -3,6 +3,7 @@
 
 #include <vector>
 #include <stdint.h>
+#include <stddef.h>
 
 struct ISzAlloc;
 typedef const ISzAlloc* ISzAllocPtr;


### PR DESCRIPTION
I was getting build errors from size_t being unrecognized, which this fixes.

Not sure why that hasn't shown up on CI or for other people but who knows.