### PR TITLE
Supreme: Add bullet selection menu

### DIFF
--- a/source/supreme/bullet.h
+++ b/source/supreme/bullet.h
@@ -69,6 +69,8 @@ enum : byte
 	BLT_FREEZE2, // a freeze bullet that drops like acid bullets and splats
 	BLT_LUNA, // lunachick's bullets
 	BLT_LUNA2, // lunachick's bullets with wall-bounce power
+
+	BLT_NUM // how many bullets there are in total. Put new types BEFORE this one!
 };
 
 // the special hammer flags for different powerups

--- a/source/supreme/bullet.h
+++ b/source/supreme/bullet.h
@@ -70,7 +70,7 @@ enum : byte
 	BLT_LUNA, // lunachick's bullets
 	BLT_LUNA2, // lunachick's bullets with wall-bounce power
 
-	BLT_NUM // how many bullets there are in total. Put new types BEFORE this one!
+	NUM_BULLETS // how many bullets there are in total. Put new types BEFORE this one!
 };
 
 // the special hammer flags for different powerups

--- a/source/supreme/bulletedit.cpp
+++ b/source/supreme/bulletedit.cpp
@@ -6,14 +6,11 @@
 #include "specialedit.h"
 
 static byte rememberMode;
-static bool realClick = false;
 
-#define ID_PICKBULLET  500
+constexpr int ID_PICKBULLET = 500;
 
 void BulletPickClick(int id)
 {
-	if (!realClick) return;
-
 	PickedTile(id - ID_PICKBULLET);
 	MakeNormalSound(SND_MENUCLICK);
 	SetEditMode(rememberMode);
@@ -23,16 +20,16 @@ void BulletEditSetupButtons(bool allowAnything)
 {
 	ClearButtons();
 
-	const int start = allowAnything ? BLT_NONE : BLT_HAMMER;
 	const int width = 160;
 	int x = 0, y = 0;
-	for (byte i = start; i < BLT_NUM; ++i)
+	for (int i = 0; i < NUM_BULLETS; ++i)
 	{
-		std::string name = BulletName(i);
-		MakeButton(BTN_NORMAL, ID_PICKBULLET + i, true, x, y, width, 16, name.c_str(), BulletPickClick);
-		y += 16;
+		if (allowAnything || i != BLT_NONE)
+			MakeButton(BTN_NORMAL, ID_PICKBULLET + i, true, x, y, width - 1, 16, BulletName(i), BulletPickClick);
+		y += 17;
 
-		if (y > 480 - 32) {
+		if (y > 480 - 32)
+		{
 			y = 0;
 			x += width;
 		}
@@ -53,8 +50,8 @@ void BulletEdit_Exit()
 
 void BulletEdit_Update(int mouseX, int mouseY, MGLDraw* mgl)
 {
-	realClick = mgl->MouseTap();
-	CheckButtons(mouseX, mouseY);
+	if (mgl->MouseTap())
+		CheckButtons(mouseX, mouseY);
 }
 
 void BulletEdit_Render(int mouseX, int mouseY, MGLDraw* mgl)
@@ -66,7 +63,8 @@ void BulletEdit_Render(int mouseX, int mouseY, MGLDraw* mgl)
 
 void BulletEdit_Key(char k)
 {
-	if (k == 27) {
+	if (k == 27)
+	{
 		PickedTile(-1);
 		SetEditMode(rememberMode);
 	}

--- a/source/supreme/bulletedit.cpp
+++ b/source/supreme/bulletedit.cpp
@@ -19,13 +19,14 @@ void BulletPickClick(int id)
 	SetEditMode(rememberMode);
 }
 
-void BulletEditSetupButtons()
+void BulletEditSetupButtons(bool allowAnything)
 {
 	ClearButtons();
 
+	const int start = allowAnything ? BLT_NONE : BLT_HAMMER;
 	const int width = 160;
 	int x = 0, y = 0;
-	for (byte i = BLT_HAMMER; i < BLT_NUM; ++i)
+	for (byte i = start; i < BLT_NUM; ++i)
 	{
 		std::string name = BulletName(i);
 		MakeButton(BTN_NORMAL, ID_PICKBULLET + i, true, x, y, width, 16, name.c_str(), BulletPickClick);
@@ -38,11 +39,11 @@ void BulletEditSetupButtons()
 	}
 }
 
-void BulletEdit_Init(byte modeFrom)
+void BulletEdit_Init(byte modeFrom, bool allowAnything)
 {
 	rememberMode = modeFrom;
 	GetDisplayMGL()->MouseTap();
-	BulletEditSetupButtons();
+	BulletEditSetupButtons(allowAnything);
 }
 
 void BulletEdit_Exit()

--- a/source/supreme/bulletedit.cpp
+++ b/source/supreme/bulletedit.cpp
@@ -1,0 +1,72 @@
+#include "bulletedit.h"
+
+#include "bullet.h"
+#include "dialogbits.h"
+#include "editor.h"
+#include "specialedit.h"
+
+static byte rememberMode;
+static bool realClick = false;
+
+#define ID_PICKBULLET  500
+
+void BulletPickClick(int id)
+{
+	if (!realClick) return;
+
+	PickedTile(id - ID_PICKBULLET);
+	MakeNormalSound(SND_MENUCLICK);
+	SetEditMode(rememberMode);
+}
+
+void BulletEditSetupButtons()
+{
+	ClearButtons();
+
+	const int width = 160;
+	int x = 0, y = 0;
+	for (byte i = BLT_HAMMER; i < BLT_NUM; ++i)
+	{
+		std::string name = BulletName(i);
+		MakeButton(BTN_NORMAL, ID_PICKBULLET + i, true, x, y, width, 16, name.c_str(), BulletPickClick);
+		y += 16;
+
+		if (y > 480 - 32) {
+			y = 0;
+			x += width;
+		}
+	}
+}
+
+void BulletEdit_Init(byte modeFrom)
+{
+	rememberMode = modeFrom;
+	GetDisplayMGL()->MouseTap();
+	BulletEditSetupButtons();
+}
+
+void BulletEdit_Exit()
+{
+
+}
+
+void BulletEdit_Update(int mouseX, int mouseY, MGLDraw* mgl)
+{
+	realClick = mgl->MouseTap();
+	CheckButtons(mouseX, mouseY);
+}
+
+void BulletEdit_Render(int mouseX, int mouseY, MGLDraw* mgl)
+{
+	mgl->ClearScreen();
+
+	RenderButtons(mouseX, mouseY, mgl);
+}
+
+void BulletEdit_Key(char k)
+{
+	if (k == 27) {
+		PickedTile(-1);
+		SetEditMode(rememberMode);
+	}
+}

--- a/source/supreme/bulletedit.h
+++ b/source/supreme/bulletedit.h
@@ -1,0 +1,11 @@
+#pragma once
+#include <jamultypes.h>
+#include <mgldraw.h>
+
+void BulletEdit_Init(byte modeFrom);
+void BulletEdit_Exit();
+
+void BulletEdit_Update(int mouseX, int mouseY, MGLDraw* mgl);
+void BulletEdit_Render(int mouseX, int mouseY, MGLDraw* mgl);
+
+void BulletEdit_Key(char k);

--- a/source/supreme/bulletedit.h
+++ b/source/supreme/bulletedit.h
@@ -1,4 +1,6 @@
-#pragma once
+#ifndef BULLETEDIT_H
+#define BULLETEDIT_H
+
 #include <jamultypes.h>
 #include <mgldraw.h>
 
@@ -9,3 +11,5 @@ void BulletEdit_Update(int mouseX, int mouseY, MGLDraw* mgl);
 void BulletEdit_Render(int mouseX, int mouseY, MGLDraw* mgl);
 
 void BulletEdit_Key(char k);
+
+#endif

--- a/source/supreme/bulletedit.h
+++ b/source/supreme/bulletedit.h
@@ -2,7 +2,7 @@
 #include <jamultypes.h>
 #include <mgldraw.h>
 
-void BulletEdit_Init(byte modeFrom);
+void BulletEdit_Init(byte modeFrom, bool allowAnything);
 void BulletEdit_Exit();
 
 void BulletEdit_Update(int mouseX, int mouseY, MGLDraw* mgl);

--- a/source/supreme/editor.cpp
+++ b/source/supreme/editor.cpp
@@ -4,6 +4,7 @@
 #include "itemedit.h"
 #include "soundedit.h"
 #include "monsteredit.h"
+#include "bulletedit.h"
 #include "specialedit.h"
 #include "tool.h"
 #include "edithelp.h"
@@ -281,6 +282,7 @@ TASK(void) UpdateMouse(void)
 		case EDITMODE_ITEM:
 		case EDITMODE_SOUND:
 		case EDITMODE_PICKENEMY:
+		case EDITMODE_PICKBULLET:
 			break;
 		default:
 			if(mouseX==0)
@@ -331,6 +333,9 @@ TASK(void) UpdateMouse(void)
 			break;
 		case EDITMODE_PICKENEMY:
 			MonsterEdit_Update(mouseX,mouseY,editmgl);
+			break;
+		case EDITMODE_PICKBULLET:
+			BulletEdit_Update(mouseX, mouseY, editmgl);
 			break;
 		case EDITMODE_EDIT:
 			if(!viewMenu || !editMenu || (ToolDoing()!=TD_USING) || (viewMenu && ViewDialogClick(mouseX,mouseY)))
@@ -792,6 +797,9 @@ void EditorDraw(void)
 			editmgl->ResizeBuffer(SCRWID, SCRHEI);
 			MonsterEdit_Render(mouseX,mouseY,editmgl);
 			break;
+		case EDITMODE_PICKBULLET:
+			BulletEdit_Render(mouseX, mouseY, editmgl);
+			break;
 		case EDITMODE_FILE:
 			editmgl->ResizeBuffer(SCRWID, SCRHEI);
 			if(displayFlags&MAP_SHOWBADGUYS)
@@ -1098,6 +1106,11 @@ static TASK(void) HandleKeyPresses(void)
 	{
 		MonsterEdit_Key(lastKey);
 		lastKey=0;
+	}
+	else if (editMode == EDITMODE_PICKBULLET)
+	{
+		BulletEdit_Key(lastKey);
+		lastKey = 0;
 	}
 	else if(editMode==EDITMODE_HELP)
 	{

--- a/source/supreme/editor.h
+++ b/source/supreme/editor.h
@@ -32,6 +32,7 @@ enum : byte
 	EDITMODE_EXITYES,
 	EDITMODE_LEVELMENU,
 	EDITMODE_EXPORT,
+	EDITMODE_PICKBULLET,
 };
 
 extern byte editing;

--- a/source/supreme/specialedit.cpp
+++ b/source/supreme/specialedit.cpp
@@ -2933,3 +2933,8 @@ void SpecialEdit_Help(void)
 	InitEditHelp(HELP_SPECIALEDIT);
 	mode=SMODE_HELP;
 }
+
+std::string BulletName(int type)
+{
+	return std::string(bulletName[type]);
+}

--- a/source/supreme/specialedit.cpp
+++ b/source/supreme/specialedit.cpp
@@ -1340,7 +1340,7 @@ static void BulletClick(int id)
 	curEff = effStart + (id - ID_EFF0) / 100;
 	mode = SMODE_PICKBULLET;
 	SetEditMode(EDITMODE_PICKBULLET);
-	BulletEdit_Init(EDITMODE_SPECIAL);
+	BulletEdit_Init(EDITMODE_SPECIAL, false);
 }
 
 static void Bullet1Click(int id)
@@ -1358,7 +1358,7 @@ static void Bullet1Click(int id)
 
 	mode = SMODE_PICKBULLET1;
 	SetEditMode(EDITMODE_PICKBULLET);
-	BulletEdit_Init(EDITMODE_SPECIAL);
+	BulletEdit_Init(EDITMODE_SPECIAL, effMode);
 }
 
 static void SetupTriggerButtons(int t,int y)

--- a/source/supreme/specialedit.cpp
+++ b/source/supreme/specialedit.cpp
@@ -6,6 +6,7 @@
 #include "items.h"
 #include "textdialog.h"
 #include "monsteredit.h"
+#include "bulletedit.h"
 #include "itemedit.h"
 #include "vars.h"
 #include "terrainedit.h"
@@ -45,6 +46,8 @@
 #define SMODE_PICKITEM3	24
 #define SMODE_HELP		25
 #define SMODE_PICKRECT3T 26
+#define SMODE_PICKBULLET 27
+#define SMODE_PICKBULLET1 28
 
 #define ID_EXIT		1
 #define ID_USES		2
@@ -254,7 +257,6 @@ static char bulletName[][20]={
 	"Lunachick Ray",
 	"Bouncy Lunachick"
 };
-#define MAX_BULLETS (BLT_LUNA2 + 1)
 
 static void SetupTriggerButtons(int t,int y);
 static void SetupEffectButtons(int t,int y);
@@ -1335,22 +1337,10 @@ static void Toggle2Click(int id)
 
 static void BulletClick(int id)
 {
-	curEff=effStart+(id-ID_EFF0)/100;
-
-	if(rightClick)
-	{
-		spcl.effect[curEff].value2--;
-		if(spcl.effect[curEff].value2<=0)
-			spcl.effect[curEff].value2=MAX_BULLETS-1;
-	}
-	else
-	{
-		spcl.effect[curEff].value2++;
-		if(spcl.effect[curEff].value2>=MAX_BULLETS)
-			spcl.effect[curEff].value2=1;
-	}
-
-	SetupEffectButtons(curEff-effStart,(curEff-effStart)*38+264);
+	curEff = effStart + (id - ID_EFF0) / 100;
+	mode = SMODE_PICKBULLET;
+	SetEditMode(EDITMODE_PICKBULLET);
+	BulletEdit_Init(EDITMODE_SPECIAL);
 }
 
 static void Bullet1Click(int id)
@@ -1359,40 +1349,16 @@ static void Bullet1Click(int id)
 	{
 		effMode=0;
 		curTrig=trgStart + id/100-1;
-
-		if(rightClick)
-		{
-			spcl.trigger[curTrig].value--;
-			if(spcl.trigger[curTrig].value<0)
-				spcl.trigger[curTrig].value=MAX_BULLETS-1;
-		}
-		else
-		{
-			spcl.trigger[curTrig].value++;
-			if(spcl.trigger[curTrig].value>=MAX_BULLETS)
-				spcl.trigger[curTrig].value=0;
-		}
-		SetupTriggerButtons(curTrig-trgStart,(curTrig-trgStart)*38+30);
 	}
 	else
 	{
 		effMode=1;
 		curEff=effStart+(id-ID_EFF0)/100;
-
-		if(rightClick)
-		{
-			spcl.effect[curEff].value--;
-			if(spcl.effect[curEff].value<0)
-				spcl.effect[curEff].value=MAX_BULLETS-1;
-		}
-		else
-		{
-			spcl.effect[curEff].value++;
-			if(spcl.effect[curEff].value>=MAX_BULLETS)
-				spcl.effect[curEff].value=0;
-		}
-		SetupEffectButtons(curEff-effStart,(curEff-effStart)*38+264);
 	}
+
+	mode = SMODE_PICKBULLET1;
+	SetEditMode(EDITMODE_PICKBULLET);
+	BulletEdit_Init(EDITMODE_SPECIAL);
 }
 
 static void SetupTriggerButtons(int t,int y)
@@ -2678,7 +2644,27 @@ void SpecialEdit_Update(int mouseX,int mouseY,int scroll,MGLDraw *mgl)
 					mode=helpRemember;
 			}
 			break;
+		case SMODE_PICKBULLET:
+			if (EditorGetLastPick() != -1)
+				spcl.effect[curEff].value2 = EditorGetLastPick();
+			mode = SMODE_NORMAL;
+			SpecialEditSetupButtons();
+			break;
+		case SMODE_PICKBULLET1:
+			if (effMode) {
+				if (EditorGetLastPick() != -1)
+					spcl.effect[curEff].value = EditorGetLastPick();
+			}
+			else
+			{
+				if (EditorGetLastPick() != -1)
+					spcl.trigger[curTrig].value = EditorGetLastPick();
+			}
 
+			mode = SMODE_NORMAL;
+			SpecialEditSetupButtons();
+			break;
+			break;
 	}
 }
 

--- a/source/supreme/specialedit.cpp
+++ b/source/supreme/specialedit.cpp
@@ -2651,7 +2651,8 @@ void SpecialEdit_Update(int mouseX,int mouseY,int scroll,MGLDraw *mgl)
 			SpecialEditSetupButtons();
 			break;
 		case SMODE_PICKBULLET1:
-			if (effMode) {
+			if (effMode)
+			{
 				if (EditorGetLastPick() != -1)
 					spcl.effect[curEff].value = EditorGetLastPick();
 			}
@@ -2663,7 +2664,6 @@ void SpecialEdit_Update(int mouseX,int mouseY,int scroll,MGLDraw *mgl)
 
 			mode = SMODE_NORMAL;
 			SpecialEditSetupButtons();
-			break;
 			break;
 	}
 }
@@ -2920,7 +2920,9 @@ void SpecialEdit_Help(void)
 	mode=SMODE_HELP;
 }
 
-std::string BulletName(int type)
+const char* BulletName(int type)
 {
-	return std::string(bulletName[type]);
+	if (type >= 0 && type < NUM_BULLETS)
+		return bulletName[type];
+	return "";
 }

--- a/source/supreme/specialedit.h
+++ b/source/supreme/specialedit.h
@@ -21,4 +21,6 @@ void SetSpecialRect(int x,int y,int x2,int y2);
 
 void SpecialEdit_Help(void);
 
+std::string BulletName(int type);
+
 #endif

--- a/source/supreme/specialedit.h
+++ b/source/supreme/specialedit.h
@@ -21,6 +21,6 @@ void SetSpecialRect(int x,int y,int x2,int y2);
 
 void SpecialEdit_Help(void);
 
-std::string BulletName(int type);
+const char* BulletName(int type);
 
 #endif


### PR DESCRIPTION
The UX for selecting bullets while editing specials is fairly clunky: the user must click through individual bullet types until they find the one they want.

This can be improved by adding a menu to select bullets. All bullets are presented in a basic list, allowing for faster selection.

The selector is designed to be automatically populated from the bullet enum, pulling bullet names from the list in `specialedit.cpp`. A `BLT_NUM` value has been added to the end of the bullet type list to enable this. For the moment, there's no handling for if the number of bullet types becomes high enought to create a fifth column of buttons, but that would require many more bullet types to be added.