### PR TITLE
LL: Add character selection to new game screen

### DIFF
--- a/source/loonyland/badge.cpp
+++ b/source/loonyland/badge.cpp
@@ -776,13 +776,7 @@ byte UpdateBadgeMenu(MGLDraw *mgl)
 					case CH_WEREWOLF:
 					case CH_SUMMON:
 					case CH_THIEF:
-						opt.cheats[CH_BONKULA]=0;
-						opt.cheats[CH_TOAD]=0;
-						opt.cheats[CH_WITCH]=0;
-						opt.cheats[CH_SWAMPDOG]=0;
-						opt.cheats[CH_WEREWOLF]=0;
-						opt.cheats[CH_SUMMON]=0;
-						opt.cheats[CH_THIEF]=0;
+						ResetCharacterCheats();
 						opt.cheats[badge[cursor].cheatNum]=1;
 						break;
 				}

--- a/source/loonyland/options.h
+++ b/source/loonyland/options.h
@@ -53,6 +53,19 @@
 #define CH_REGEN	38		// monster regeneration
 #define CH_NOFARLEY 39		// no farley
 
+enum PlayerCharacterType : int
+{
+	PC_Loony = 0,
+	PC_Bonkula = 1,
+	PC_Toad = 2,
+	PC_Swampdog = 3,
+	PC_Witch = 4,
+	PC_Werewolf = 5,
+	PC_Summon = 6,
+	PC_Thief = 7,
+	PC_MAX
+};
+
 typedef struct options_t
 {
 	byte control[2][6];	// key scancodes
@@ -78,5 +91,11 @@ void SaveOptions(void);
 
 TASK(void) OptionsMenu(MGLDraw *mgl);
 void KilledBoss(byte boss);
+
+bool IsAnyCharacterUnlocked();
+void NextCharacter();
+void PrevCharacter();
+void ResetCharacterCheats();
+PlayerCharacterType GetCurrentPC();
 
 #endif

--- a/source/loonyland/title.cpp
+++ b/source/loonyland/title.cpp
@@ -442,6 +442,18 @@ void DiffChooseDisplay(MGLDraw *mgl)
 	}
 }
 
+void CharacterChooseDisplay(MGLDraw* mgl)
+{
+	if (!IsAnyCharacterUnlocked())
+		return;
+
+	char playerName[PC_MAX][9] = {"Loony","Bonkula","Toad","Swampdog","Witch","Werewolf","Summony","Ninja"};
+
+	//PrintGlow(280, 200, "^", 0, 2);
+	PrintGlow(200, 200, "Character:", 0, 2);
+	PrintGlow(200, 260, "Use up and down to select a character.", 0, 1);
+	CenterPrintGlow(440, 200, playerName[GetCurrentPC()], 0, 2);
+}
 
 void LoadGameDisplay(MGLDraw *mgl)
 {
@@ -686,6 +698,16 @@ byte ChooseDiffUpdate(int *lastTime,MGLDraw *mgl)
 				opt.difficulty++;
 			MakeNormalSound(SND_MENUCLICK);
 		}
+		if ((c & CONTROL_DN) && !(oldc & CONTROL_DN) && IsAnyCharacterUnlocked())
+		{
+			NextCharacter();
+			MakeNormalSound(SND_MENUCLICK);
+		}
+		if ((c & CONTROL_UP) && !(oldc & CONTROL_UP) && IsAnyCharacterUnlocked())
+		{
+			PrevCharacter();
+			MakeNormalSound(SND_MENUCLICK);
+		}
 
 		if((c&(CONTROL_B1|CONTROL_B2)) && !(oldc&(CONTROL_B1|CONTROL_B2)))
 		{
@@ -789,6 +811,7 @@ TASK(byte) MainMenu(MGLDraw *mgl)
 		{
 			b=ChooseDiffUpdate(&lastTime,mgl);
 			DiffChooseDisplay(mgl);
+			CharacterChooseDisplay(mgl);
 			if(b==0)
 			{
 				cursor=0;


### PR DESCRIPTION
Allows the character to be selected when starting a new normal or remix game, for convenience. This is done with some helper functions and maps that set the appropriate merit badge effects when called. The player can only select characters that are unlocked, and the selection doesn't appear at all if no characters have been unlocked.